### PR TITLE
Fix 'not example'

### DIFF
--- a/spec/search-api.json
+++ b/spec/search-api.json
@@ -246,7 +246,10 @@
                     },
                     {
                       "not": {
-                        "or": [
+                        "type": "selection",
+                        "constraint": "occupationCategory",
+                        "mode": "or",
+                        "value": [
                           "marketing",
                           "support"
                         ]


### PR DESCRIPTION
Without type and constraint, there is no way to understand what this
"not marketing or support" means

Fixes #5